### PR TITLE
set _POSIX_C_SOURCE=200112L in CFLAGS

### DIFF
--- a/allocator.go
+++ b/allocator.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 #include "allocator.h"
 */

--- a/edit.go
+++ b/edit.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/language.go
+++ b/language.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/lookahead_iterator.go
+++ b/lookahead_iterator.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/node.go
+++ b/node.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/parser.go
+++ b/parser.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 #include <stdio.h>
 

--- a/point.go
+++ b/point.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/query.go
+++ b/query.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 #include "lib.c"
 */

--- a/ranges.go
+++ b/ranges.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/tree.go
+++ b/tree.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/tree_cursor.go
+++ b/tree_cursor.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
 #include <tree_sitter/api.h>
 */
 import "C"


### PR DESCRIPTION
Prior to this commit _POSIX_C_SOURCE was defined first in <stdlib.h> which is included by cgo first[1]. By default <stdlib.h> sets _POSIX_C_SOURCE=199506L, which conflicts with tree-sitter's setting of _POSIX_C_SOURCE=200112L. After this commit we use a CFLAG to set the feature macro before any files are included.

[1]: https://github.com/golang/go/issues/35315

Fixes: #7