### PR TITLE
Set minimum go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tree-sitter/go-tree-sitter
 
-go 1.23
+go 1.22
 
 require (
 	github.com/mattn/go-pointer v0.0.1


### PR DESCRIPTION
Per the tin, I'd like to set the minimum version to 1.22 from 1.23 (the latest).

My reasoning is that folks don't always immediately move to the latest version and I'm hoping this repo could exist at a more friendly minimum Go version. Given the newness of the repo, I suspect this may not have been intentional, but it may be good to have some sort of documented policy on the supported Go version(s).