### PR TITLE
feat: bump lib to 0.24

### DIFF
--- a/allocator.go
+++ b/allocator.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 #include "allocator.h"
 */

--- a/edit.go
+++ b/edit.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/include/tree_sitter/api.h
+++ b/include/tree_sitter/api.h
@@ -50,12 +50,14 @@ typedef struct TSLookaheadIterator TSLookaheadIterator;
 
 typedef enum TSInputEncoding {
   TSInputEncodingUTF8,
-  TSInputEncodingUTF16,
+  TSInputEncodingUTF16LE,
+  TSInputEncodingUTF16BE,
 } TSInputEncoding;
 
 typedef enum TSSymbolType {
   TSSymbolTypeRegular,
   TSSymbolTypeAnonymous,
+  TSSymbolTypeSupertype,
   TSSymbolTypeAuxiliary,
 } TSSymbolType;
 
@@ -554,9 +556,21 @@ TSStateId ts_node_next_parse_state(TSNode self);
 TSNode ts_node_parent(TSNode self);
 
 /**
- * Get the node's child that contains `descendant`.
+ * @deprecated use [`ts_node_contains_descendant`] instead, this will be removed in 0.25
+ *
+ * Get the node's child containing `descendant`. This will not return
+ * the descendant if it is a direct child of `self`, for that use
+ * `ts_node_contains_descendant`.
  */
 TSNode ts_node_child_containing_descendant(TSNode self, TSNode descendant);
+
+/**
+ * Get the node that contains `descendant`.
+ *
+ * Note that this can return `descendant` itself, unlike the deprecated function
+ * [`ts_node_child_containing_descendant`].
+ */
+TSNode ts_node_child_with_descendant(TSNode self, TSNode descendant);
 
 /**
  * Get the node's child at the given index, where zero represents the first
@@ -569,6 +583,12 @@ TSNode ts_node_child(TSNode self, uint32_t child_index);
  * the first child. Returns NULL, if no field is found.
  */
 const char *ts_node_field_name_for_child(TSNode self, uint32_t child_index);
+
+/**
+ * Get the field name for node's named child at the given index, where zero
+ * represents the first named child. Returns NULL, if no field is found.
+ */
+const char *ts_node_field_name_for_named_child(TSNode self, uint32_t named_child_index);
 
 /**
  * Get the node's number of children.

--- a/language.go
+++ b/language.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 */
 import "C"
@@ -59,8 +59,15 @@ func (l *Language) NodeKindIsNamed(id uint16) bool {
 	return C.ts_language_symbol_type(l.Inner, C.TSSymbol(id)) == C.TSSymbolTypeRegular
 }
 
+// Check if the node type for the given numerical id is visible (as opposed
+// to a hidden node type).
 func (l *Language) NodeKindIsVisible(id uint16) bool {
 	return C.ts_language_symbol_type(l.Inner, C.TSSymbol(id)) <= C.TSSymbolTypeAnonymous
+}
+
+// Check if the node type for the given numerical id is a supertype.
+func (l *Language) NodeKindIsSupertype(id uint16) bool {
+	return C.ts_language_symbol_type(l.Inner, C.TSSymbol(id)) == C.TSSymbolTypeSupertype
 }
 
 // Get the number of distinct field names in this language.

--- a/language_test.go
+++ b/language_test.go
@@ -1,0 +1,28 @@
+package tree_sitter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSymbolMetadataChecks(t *testing.T) {
+	language := getLanguage("rust")
+	for id := range language.NodeKindCount() {
+		name := language.NodeKindForId(uint16(id))
+
+		switch name {
+		case "_type", "_expression", "_pattern", "_literal", "_literal_pattern", "_declaration_statement":
+			assert.True(t, language.NodeKindIsSupertype(uint16(id)))
+
+		case "_raw_string_literal_start", "_raw_string_literal_end", "_line_doc_comment", "_error_sentinel":
+			assert.False(t, language.NodeKindIsSupertype(uint16(id)))
+
+		case "enum_item", "struct_item", "type_item":
+			assert.True(t, language.NodeKindIsNamed(uint16(id)))
+
+		case "=>", "[", "]", "(", ")", "{", "}":
+			assert.True(t, language.NodeKindIsVisible(uint16(id)))
+		}
+	}
+}

--- a/lookahead_iterator.go
+++ b/lookahead_iterator.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/node.go
+++ b/node.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 */
 import "C"
@@ -209,6 +209,15 @@ func (n *Node) FieldNameForChild(childIndex uint32) string {
 	return C.GoString(ptr)
 }
 
+// Get the field name of this node's named child at the given index.
+func (n *Node) FieldNameForNamedChild(namedChildIndex uint32) string {
+	ptr := C.ts_node_field_name_for_named_child(n._inner, C.uint32_t(namedChildIndex))
+	if ptr == nil {
+		return ""
+	}
+	return C.GoString(ptr)
+}
+
 // Iterate over this node's children.
 //
 // A [TreeCursor] is used to retrieve the children efficiently. Obtain
@@ -282,9 +291,19 @@ func (n *Node) Parent() *Node {
 	return newNode(C.ts_node_parent(n._inner))
 }
 
-// Get this node's child that contains descendant.
+// Deprecated: Prefer [Node.ChildWithDescendant] instead, this will be removed in 0.25
+// Get the node's child containing `descendant`. This will not return
+// the descendant if it is a direct child of `self`, for that use
+// [Node.ChildWithDescendant].
 func (n *Node) ChildContainingDescendant(descendant *Node) *Node {
 	return newNode(C.ts_node_child_containing_descendant(n._inner, descendant._inner))
+}
+
+// Get the node that contains `descendant`.
+// Note that this can return `descendant` itself, unlike the deprecated function
+// [Node.ChildContainingDescendant].
+func (n *Node) ChildWithDescendant(descendant *Node) *Node {
+	return newNode(C.ts_node_child_with_descendant(n._inner, descendant._inner))
 }
 
 // Get this node's next sibling.

--- a/point.go
+++ b/point.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/query.go
+++ b/query.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 #include "lib.c"
 */

--- a/ranges.go
+++ b/ranges.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -15,10 +15,10 @@ extern "C" {
 #define TS_PUBLIC __attribute__((visibility("default")))
 #endif
 
-TS_PUBLIC extern void *(*ts_current_malloc)(size_t);
-TS_PUBLIC extern void *(*ts_current_calloc)(size_t, size_t);
-TS_PUBLIC extern void *(*ts_current_realloc)(void *, size_t);
-TS_PUBLIC extern void (*ts_current_free)(void *);
+TS_PUBLIC extern void *(*ts_current_malloc)(size_t size);
+TS_PUBLIC extern void *(*ts_current_calloc)(size_t count, size_t size);
+TS_PUBLIC extern void *(*ts_current_realloc)(void *ptr, size_t size);
+TS_PUBLIC extern void (*ts_current_free)(void *ptr);
 
 // Allow clients to override allocation functions
 #ifndef ts_malloc

--- a/src/array.h
+++ b/src/array.h
@@ -6,8 +6,8 @@ extern "C" {
 #endif
 
 #include "./alloc.h"
+#include "./ts_assert.h"
 
-#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -37,7 +37,7 @@ extern "C" {
 
 /// Get a pointer to the element at a given `index` in the array.
 #define array_get(self, _index) \
-  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+  (ts_assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
 
 /// Get a pointer to the first element in the array.
 #define array_front(self) array_get(self, 0)
@@ -171,7 +171,7 @@ static inline void _array__delete(Array *self) {
 /// This is not what you're looking for, see `array_erase`.
 static inline void _array__erase(Array *self, size_t element_size,
                                 uint32_t index) {
-  assert(index < self->size);
+  ts_assert(index < self->size);
   char *contents = (char *)self->contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
           (self->size - index - 1) * element_size);
@@ -222,7 +222,7 @@ static inline void _array__splice(Array *self, size_t element_size,
   uint32_t new_size = self->size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;
-  assert(old_end <= self->size);
+  ts_assert(old_end <= self->size);
 
   _array__reserve(self, element_size, new_size);
 

--- a/src/get_changed_ranges.c
+++ b/src/get_changed_ranges.c
@@ -3,7 +3,7 @@
 #include "./language.h"
 #include "./error_costs.h"
 #include "./tree_cursor.h"
-#include <assert.h>
+#include "./ts_assert.h"
 
 // #define DEBUG_GET_CHANGED_RANGES
 

--- a/src/language.c
+++ b/src/language.c
@@ -43,7 +43,7 @@ void ts_language_table_entry(
     result->is_reusable = false;
     result->actions = NULL;
   } else {
-    assert(symbol < self->token_count);
+    ts_assert(symbol < self->token_count);
     uint32_t action_index = ts_language_lookup(self, state, symbol);
     const TSParseActionEntry *entry = &self->parse_actions[action_index];
     result->action_count = entry->entry.count;
@@ -138,6 +138,8 @@ TSSymbolType ts_language_symbol_type(
     return TSSymbolTypeRegular;
   } else if (metadata.visible) {
     return TSSymbolTypeAnonymous;
+  } else if (metadata.supertype) {
+    return TSSymbolTypeSupertype;
   } else {
     return TSSymbolTypeAuxiliary;
   }

--- a/src/language.h
+++ b/src/language.h
@@ -35,13 +35,11 @@ typedef struct {
   uint16_t action_count;
 } LookaheadIterator;
 
-void ts_language_table_entry(const TSLanguage *, TSStateId, TSSymbol, TableEntry *);
+void ts_language_table_entry(const TSLanguage *self, TSStateId state, TSSymbol symbol, TableEntry *result);
 
-TSSymbolMetadata ts_language_symbol_metadata(const TSLanguage *, TSSymbol);
+TSSymbolMetadata ts_language_symbol_metadata(const TSLanguage *self, TSSymbol symbol);
 
-TSSymbol ts_language_public_symbol(const TSLanguage *, TSSymbol);
-
-TSStateId ts_language_next_state(const TSLanguage *self, TSStateId state, TSSymbol symbol);
+TSSymbol ts_language_public_symbol(const TSLanguage *self, TSSymbol symbol);
 
 static inline bool ts_language_is_symbol_external(const TSLanguage *self, TSSymbol symbol) {
   return 0 < symbol && symbol < self->external_token_count + 1;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -83,9 +83,9 @@ static void ts_lexer__get_lookahead(Lexer *self) {
   }
 
   const uint8_t *chunk = (const uint8_t *)self->chunk + position_in_chunk;
-  UnicodeDecodeFunction decode = self->input.encoding == TSInputEncodingUTF8
-    ? ts_decode_utf8
-    : ts_decode_utf16;
+  UnicodeDecodeFunction decode =
+    self->input.encoding == TSInputEncodingUTF8 ? ts_decode_utf8 :
+    self->input.encoding == TSInputEncodingUTF16LE ? ts_decode_utf16_le : ts_decode_utf16_be;
 
   self->lookahead_size = decode(chunk, size, &self->data.lookahead);
 
@@ -252,12 +252,12 @@ static uint32_t ts_lexer__get_column(TSLexer *_self) {
   uint32_t goal_byte = self->current_position.bytes;
 
   self->did_get_column = true;
-  self->current_position.bytes -= self->current_position.extent.column;
-  self->current_position.extent.column = 0;
-
-  if (self->current_position.bytes < self->chunk_start) {
-    ts_lexer__get_chunk(self);
-  }
+  Length start_of_col = {
+    self->current_position.bytes - self->current_position.extent.column,
+    {self->current_position.extent.row, 0},
+  };
+  ts_lexer_goto(self, start_of_col);
+  ts_lexer__get_chunk(self);
 
   uint32_t result = 0;
   if (!ts_lexer__eof(_self)) {
@@ -367,7 +367,10 @@ void ts_lexer_finish(Lexer *self, uint32_t *lookahead_end_byte) {
   // If the token ended at an included range boundary, then its end position
   // will have been reset to the end of the preceding range. Reset the start
   // position to match.
-  if (self->token_end_position.bytes < self->token_start_position.bytes) {
+  if (
+    self->token_end_position.bytes < self->token_start_position.bytes ||
+    point_lt(self->token_end_position.extent, self->token_start_position.extent)
+  ) {
     self->token_start_position = self->token_end_position;
   }
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -31,14 +31,14 @@ typedef struct {
   char debug_buffer[TREE_SITTER_SERIALIZATION_BUFFER_SIZE];
 } Lexer;
 
-void ts_lexer_init(Lexer *);
-void ts_lexer_delete(Lexer *);
-void ts_lexer_set_input(Lexer *, TSInput);
-void ts_lexer_reset(Lexer *, Length);
-void ts_lexer_start(Lexer *);
-void ts_lexer_finish(Lexer *, uint32_t *);
-void ts_lexer_advance_to_end(Lexer *);
-void ts_lexer_mark_end(Lexer *);
+void ts_lexer_init(Lexer *self);
+void ts_lexer_delete(Lexer *self);
+void ts_lexer_set_input(Lexer *self, TSInput input);
+void ts_lexer_reset(Lexer *self, Length position);
+void ts_lexer_start(Lexer *self);
+void ts_lexer_finish(Lexer *self, uint32_t *lookahead_end_byte);
+void ts_lexer_advance_to_end(Lexer *self);
+void ts_lexer_mark_end(Lexer *self);
 bool ts_lexer_set_included_ranges(Lexer *self, const TSRange *ranges, uint32_t count);
 TSRange *ts_lexer_included_ranges(const Lexer *self, uint32_t *count);
 

--- a/src/lib.c
+++ b/src/lib.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200112L
-
 #include "./alloc.c"
 #include "./get_changed_ranges.c"
 #include "./language.c"

--- a/src/node.c
+++ b/src/node.c
@@ -12,6 +12,8 @@ typedef struct {
   const TSSymbol *alias_sequence;
 } NodeChildIterator;
 
+static inline bool ts_node__is_relevant(TSNode self, bool include_anonymous);
+
 // TSNode - constructors
 
 TSNode ts_node_new(
@@ -99,6 +101,21 @@ static inline bool ts_node_child_iterator_next(
   self->position = length_add(self->position, ts_subtree_size(*child));
   self->child_index++;
   return true;
+}
+
+// This will return true if the next sibling is a zero-width token that is adjacent to the current node and is relevant
+static inline bool ts_node_child_iterator_next_sibling_is_empty_adjacent(NodeChildIterator *self, TSNode previous) {
+  if (!self->parent.ptr || ts_node_child_iterator_done(self)) return false;
+  if (self->child_index == 0) return false;
+  const Subtree *child = &ts_subtree_children(self->parent)[self->child_index];
+  TSSymbol alias = 0;
+  if (!ts_subtree_extra(*child)) {
+    if (self->alias_sequence) {
+      alias = self->alias_sequence[self->structural_child_index];
+    }
+  }
+  TSNode next = ts_node_new(self->tree, child, self->position, alias);
+  return ts_node_end_byte(previous) == ts_node_end_byte(next) && ts_node__is_relevant(next, true);
 }
 
 // TSNode - private
@@ -304,21 +321,35 @@ static inline TSNode ts_node__first_child_for_byte(
   TSNode node = self;
   bool did_descend = true;
 
+  NodeChildIterator last_iterator;
+  bool has_last_iterator = false;
+
   while (did_descend) {
     did_descend = false;
 
     TSNode child;
     NodeChildIterator iterator = ts_node_iterate_children(&node);
+  loop:
     while (ts_node_child_iterator_next(&iterator, &child)) {
       if (ts_node_end_byte(child) > goal) {
         if (ts_node__is_relevant(child, include_anonymous)) {
           return child;
         } else if (ts_node_child_count(child) > 0) {
+          if (iterator.child_index < ts_subtree_child_count(ts_node__subtree(child))) {
+            last_iterator = iterator;
+            has_last_iterator = true;
+          }
           did_descend = true;
           node = child;
           break;
         }
       }
+    }
+
+    if (!did_descend && has_last_iterator) {
+      iterator = last_iterator;
+      has_last_iterator = false;
+      goto loop;
     }
   }
 
@@ -344,9 +375,13 @@ static inline TSNode ts_node__descendant_for_byte_range(
       uint32_t node_end = iterator.position.bytes;
 
       // The end of this node must extend far enough forward to touch
-      // the end of the range and exceed the start of the range.
+      // the end of the range
       if (node_end < range_end) continue;
-      if (node_end <= range_start) continue;
+
+      // ...and exceed the start of the range, unless the node itself is
+      // empty, in which case it must at least be equal to the start of the range.
+      bool is_empty = ts_node_start_byte(child) == node_end;
+      if (is_empty ? node_end < range_start : node_end <= range_start) continue;
 
       // The start of this node must extend far enough backward to
       // touch the start of the range.
@@ -383,9 +418,15 @@ static inline TSNode ts_node__descendant_for_point_range(
       TSPoint node_end = iterator.position.extent;
 
       // The end of this node must extend far enough forward to touch
-      // the end of the range and exceed the start of the range.
+      // the end of the range
       if (point_lt(node_end, range_end)) continue;
-      if (point_lte(node_end, range_start)) continue;
+
+      // ...and exceed the start of the range, unless the node itself is
+      // empty, in which case it must at least be equal to the start of the range.
+      bool is_empty =  point_eq(ts_node_start_point(child), node_end);
+      if (is_empty ? point_lt(node_end, range_start) : point_lte(node_end, range_start)) {
+        continue;
+      }
 
       // The start of this node must extend far enough backward to
       // touch the start of the range.
@@ -516,9 +557,9 @@ TSNode ts_node_parent(TSNode self) {
   return node;
 }
 
-TSNode ts_node_child_containing_descendant(TSNode self, TSNode subnode) {
-  uint32_t start_byte = ts_node_start_byte(subnode);
-  uint32_t end_byte = ts_node_end_byte(subnode);
+TSNode ts_node_child_containing_descendant(TSNode self, TSNode descendant) {
+  uint32_t start_byte = ts_node_start_byte(descendant);
+  uint32_t end_byte = ts_node_end_byte(descendant);
 
   do {
     NodeChildIterator iter = ts_node_iterate_children(&self);
@@ -526,10 +567,68 @@ TSNode ts_node_child_containing_descendant(TSNode self, TSNode subnode) {
       if (
         !ts_node_child_iterator_next(&iter, &self)
         || ts_node_start_byte(self) > start_byte
-        || self.id == subnode.id
+        || self.id == descendant.id
       ) {
         return ts_node__null();
       }
+
+      // Here we check the current self node and *all* of its zero-width token siblings that follow.
+      // If any of these nodes contain the target subnode, we return that node. Otherwise, we restore the node we started at
+      // for the loop condition, and that will continue with the next *non-zero-width* sibling.
+      TSNode old = self;
+      // While the next sibling is a zero-width token
+      while (ts_node_child_iterator_next_sibling_is_empty_adjacent(&iter, self)) {
+        TSNode current_node = ts_node_child_containing_descendant(self, descendant);
+        // If the target child is in self, return it
+        if (!ts_node_is_null(current_node)) {
+          return current_node;
+        }
+        ts_node_child_iterator_next(&iter, &self);
+        if (self.id == descendant.id) {
+          return ts_node__null();
+        }
+      }
+      self = old;
+    } while (iter.position.bytes < end_byte || ts_node_child_count(self) == 0);
+  } while (!ts_node__is_relevant(self, true));
+
+  return self;
+}
+
+TSNode ts_node_child_with_descendant(TSNode self, TSNode descendant) {
+  uint32_t start_byte = ts_node_start_byte(descendant);
+  uint32_t end_byte = ts_node_end_byte(descendant);
+
+  do {
+    NodeChildIterator iter = ts_node_iterate_children(&self);
+    do {
+      if (
+        !ts_node_child_iterator_next(&iter, &self)
+        || ts_node_start_byte(self) > start_byte
+      ) {
+        return ts_node__null();
+      }
+      if (self.id == descendant.id) {
+        return self;
+      }
+
+      // Here we check the current self node and *all* of its zero-width token siblings that follow.
+      // If any of these nodes contain the target subnode, we return that node. Otherwise, we restore the node we started at
+      // for the loop condition, and that will continue with the next *non-zero-width* sibling.
+      TSNode old = self;
+      // While the next sibling is a zero-width token
+      while (ts_node_child_iterator_next_sibling_is_empty_adjacent(&iter, self)) {
+        TSNode current_node = ts_node_child_with_descendant(self, descendant);
+        // If the target child is in self, return it
+        if (!ts_node_is_null(current_node)) {
+          return current_node;
+        }
+        ts_node_child_iterator_next(&iter, &self);
+        if (self.id == descendant.id) {
+          return self;
+        }
+      }
+      self = old;
     } while (iter.position.bytes < end_byte || ts_node_child_count(self) == 0);
   } while (!ts_node__is_relevant(self, true));
 
@@ -664,6 +763,48 @@ const char *ts_node_field_name_for_child(TSNode self, uint32_t child_index) {
           did_descend = true;
           result = child;
           child_index = grandchild_index;
+          break;
+        }
+        index += grandchild_count;
+      }
+    }
+  }
+
+  return NULL;
+}
+
+const char *ts_node_field_name_for_named_child(TSNode self, uint32_t named_child_index) {
+  TSNode result = self;
+  bool did_descend = true;
+  const char *inherited_field_name = NULL;
+
+  while (did_descend) {
+    did_descend = false;
+
+    TSNode child;
+    uint32_t index = 0;
+    NodeChildIterator iterator = ts_node_iterate_children(&result);
+    while (ts_node_child_iterator_next(&iterator, &child)) {
+      if (ts_node__is_relevant(child, false)) {
+        if (index == named_child_index) {
+          if (ts_node_is_extra(child)) {
+            return NULL;
+          }
+          const char *field_name = ts_node__field_name_from_language(result, iterator.structural_child_index - 1);
+          if (field_name) return field_name;
+          return inherited_field_name;
+        }
+        index++;
+      } else {
+        uint32_t named_grandchild_index = named_child_index - index;
+        uint32_t grandchild_count = ts_node__relevant_child_count(child, false);
+        if (named_grandchild_index < grandchild_count) {
+          const char *field_name = ts_node__field_name_from_language(result, iterator.structural_child_index - 1);
+          if (field_name) inherited_field_name = field_name;
+
+          did_descend = true;
+          result = child;
+          named_child_index = named_grandchild_index;
           break;
         }
         index += grandchild_count;

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,7 +1,4 @@
-#define _POSIX_C_SOURCE 200112L
-
 #include <time.h>
-#include <assert.h>
 #include <stdio.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -21,6 +18,7 @@
 #include "./stack.h"
 #include "./subtree.h"
 #include "./tree.h"
+#include "./ts_assert.h"
 #include "./wasm_store.h"
 
 #define LOG(...)                                                                            \
@@ -350,7 +348,7 @@ static bool ts_parser__call_main_lex_fn(TSParser *self, TSLexMode lex_mode) {
   }
 }
 
-static bool ts_parser__call_keyword_lex_fn(TSParser *self, TSLexMode lex_mode) {
+static bool ts_parser__call_keyword_lex_fn(TSParser *self) {
   if (ts_language_is_wasm(self->language)) {
     return ts_wasm_store_call_lex_keyword(self->wasm_store, 0);
   } else {
@@ -405,7 +403,7 @@ static unsigned ts_parser__external_scanner_serialize(
       self->external_scanner_payload,
       self->lexer.debug_buffer
     );
-    assert(length <= TREE_SITTER_SERIALIZATION_BUFFER_SIZE);
+    ts_assert(length <= TREE_SITTER_SERIALIZATION_BUFFER_SIZE);
     return length;
   }
 }
@@ -651,7 +649,7 @@ static Subtree ts_parser__lex(
       ts_lexer_reset(&self->lexer, self->lexer.token_start_position);
       ts_lexer_start(&self->lexer);
 
-      is_keyword = ts_parser__call_keyword_lex_fn(self, lex_mode);
+      is_keyword = ts_parser__call_keyword_lex_fn(self);
 
       if (
         is_keyword &&
@@ -1041,7 +1039,7 @@ static void ts_parser__accept(
   StackVersion version,
   Subtree lookahead
 ) {
-  assert(ts_subtree_is_eof(lookahead));
+  ts_assert(ts_subtree_is_eof(lookahead));
   ts_stack_push(self->stack, version, lookahead, false, 1);
 
   StackSliceArray pop = ts_stack_pop_all(self->stack, version);
@@ -1052,7 +1050,7 @@ static void ts_parser__accept(
     for (uint32_t j = trees.size - 1; j + 1 > 0; j--) {
       Subtree tree = trees.contents[j];
       if (!ts_subtree_extra(tree)) {
-        assert(!tree.data.is_inline);
+        ts_assert(!tree.data.is_inline);
         uint32_t child_count = ts_subtree_child_count(tree);
         const Subtree *children = ts_subtree_children(tree);
         for (uint32_t k = 0; k < child_count; k++) {
@@ -1070,7 +1068,7 @@ static void ts_parser__accept(
       }
     }
 
-    assert(root.ptr);
+    ts_assert(root.ptr);
     self->accept_count++;
 
     if (self->finished_tree.ptr) {
@@ -1206,7 +1204,7 @@ static bool ts_parser__recover_to_state(
 
     SubtreeArray error_trees = ts_stack_pop_error(self->stack, slice.version);
     if (error_trees.size > 0) {
-      assert(error_trees.size == 1);
+      ts_assert(error_trees.size == 1);
       Subtree error_tree = error_trees.contents[0];
       uint32_t error_child_count = ts_subtree_child_count(error_tree);
       if (error_child_count > 0) {
@@ -1494,8 +1492,7 @@ static void ts_parser__handle_error(
 
   for (unsigned i = previous_version_count; i < version_count; i++) {
     bool did_merge = ts_stack_merge(self->stack, version, previous_version_count);
-    assert(did_merge);
-    (void)did_merge;	//	fix warning/error with clang -Os
+    ts_assert(did_merge);
   }
 
   ts_stack_record_summary(self->stack, version, MAX_SUMMARY_DEPTH);
@@ -2101,7 +2098,7 @@ TSTree *ts_parser_parse(
     }
   } while (version_count != 0);
 
-  assert(self->finished_tree.ptr);
+  ts_assert(self->finished_tree.ptr);
   ts_subtree_balance(self->finished_tree, &self->tree_pool, self->language);
   LOG("done");
   LOG_TREE(self->finished_tree);

--- a/src/portable/endian.h
+++ b/src/portable/endian.h
@@ -1,0 +1,206 @@
+// "License": Public Domain
+// I, Mathias Panzenböck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
+// In case there are jurisdictions that don't support putting things in the public domain you can also consider it to
+// be "dual licensed" under the BSD, MIT and Apache licenses, if you want to. This code is trivial anyway. Consider it
+// an example on how to get the endian conversion functions on different platforms.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#    define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__) || defined(__EMSCRIPTEN__)
+
+#    include <endian.h>
+
+#elif defined(__APPLE__)
+
+#    include <libkern/OSByteOrder.h>
+
+#    define htobe16(x) OSSwapHostToBigInt16(x)
+#    define htole16(x) OSSwapHostToLittleInt16(x)
+#    define be16toh(x) OSSwapBigToHostInt16(x)
+#    define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#    define htobe32(x) OSSwapHostToBigInt32(x)
+#    define htole32(x) OSSwapHostToLittleInt32(x)
+#    define be32toh(x) OSSwapBigToHostInt32(x)
+#    define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#    define htobe64(x) OSSwapHostToBigInt64(x)
+#    define htole64(x) OSSwapHostToLittleInt64(x)
+#    define be64toh(x) OSSwapBigToHostInt64(x)
+#    define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#    define __BYTE_ORDER    BYTE_ORDER
+#    define __BIG_ENDIAN    BIG_ENDIAN
+#    define __LITTLE_ENDIAN LITTLE_ENDIAN
+#    define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#    include <endian.h>
+
+#    define __BYTE_ORDER    BYTE_ORDER
+#    define __BIG_ENDIAN    BIG_ENDIAN
+#    define __LITTLE_ENDIAN LITTLE_ENDIAN
+#    define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#    include <sys/endian.h>
+
+#    define be16toh(x) betoh16(x)
+#    define le16toh(x) letoh16(x)
+
+#    define be32toh(x) betoh32(x)
+#    define le32toh(x) letoh32(x)
+
+#    define be64toh(x) betoh64(x)
+#    define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+
+#    if defined(_MSC_VER) && !defined(__clang__)
+#        include <stdlib.h>
+#        define B_SWAP_16(x) _byteswap_ushort(x)
+#        define B_SWAP_32(x) _byteswap_ulong(x)
+#        define B_SWAP_64(x) _byteswap_uint64(x)
+#    else
+#        define B_SWAP_16(x) __builtin_bswap16(x)
+#        define B_SWAP_32(x) __builtin_bswap32(x)
+#        define B_SWAP_64(x) __builtin_bswap64(x)
+#    endif
+
+# if defined(__MINGW32__) || defined(HAVE_SYS_PARAM_H)
+#   include <sys/param.h>
+# endif
+
+#    ifndef BIG_ENDIAN
+#        ifdef __BIG_ENDIAN
+#            define BIG_ENDIAN __BIG_ENDIAN
+#        elif defined(__ORDER_BIG_ENDIAN__)
+#            define BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#        else
+#            define BIG_ENDIAN 4321
+#        endif
+#    endif
+
+#    ifndef LITTLE_ENDIAN
+#        ifdef __LITTLE_ENDIAN
+#            define LITTLE_ENDIAN __LITTLE_ENDIAN
+#        elif defined(__ORDER_LITTLE_ENDIAN__)
+#            define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#        else
+#            define LITTLE_ENDIAN 1234
+#        endif
+#    endif
+
+#    ifndef BYTE_ORDER
+#        ifdef __BYTE_ORDER
+#            define BYTE_ORDER __BYTE_ORDER
+#        elif defined(__BYTE_ORDER__)
+#            define BYTE_ORDER __BYTE_ORDER__
+#        else
+             /* assume LE on Windows if nothing was defined */
+#            define BYTE_ORDER LITTLE_ENDIAN
+#        endif
+#    endif
+
+#    if BYTE_ORDER == LITTLE_ENDIAN
+
+#        define htobe16(x) B_SWAP_16(x)
+#        define htole16(x) (x)
+#        define be16toh(x) B_SWAP_16(x)
+#        define le16toh(x) (x)
+
+#        define htobe32(x) B_SWAP_32(x)
+#        define htole32(x) (x)
+#        define be32toh(x) B_SWAP_32(x)
+#        define le32toh(x) (x)
+
+#        define htobe64(x) B_SWAP_64(x)
+#        define htole64(x) (x)
+#        define be64toh(x) B_SWAP_64(x)
+#        define le64toh(x) (x)
+
+#    elif BYTE_ORDER == BIG_ENDIAN
+
+#        define htobe16(x) (x)
+#        define htole16(x) B_SWAP_16(x)
+#        define be16toh(x) (x)
+#        define le16toh(x) B_SWAP_16(x)
+
+#        define htobe32(x) (x)
+#        define htole32(x) B_SWAP_32(x)
+#        define be32toh(x) (x)
+#        define le32toh(x) B_SWAP_32(x)
+
+#        define htobe64(x) (x)
+#        define htole64(x) B_SWAP_64(x)
+#        define be64toh(x) (x)
+#        define le64toh(x) B_SWAP_64(x)
+
+#    else
+
+#        error byte order not supported
+
+#    endif
+
+#elif defined(__QNXNTO__)
+
+#    include <gulliver.h>
+
+#    define __LITTLE_ENDIAN 1234
+#    define __BIG_ENDIAN    4321
+#    define __PDP_ENDIAN    3412
+
+#    if defined(__BIGENDIAN__)
+
+#        define __BYTE_ORDER __BIG_ENDIAN
+
+#        define htobe16(x) (x)
+#        define htobe32(x) (x)
+#        define htobe64(x) (x)
+
+#        define htole16(x) ENDIAN_SWAP16(x)
+#        define htole32(x) ENDIAN_SWAP32(x)
+#        define htole64(x) ENDIAN_SWAP64(x)
+
+#    elif defined(__LITTLEENDIAN__)
+
+#        define __BYTE_ORDER __LITTLE_ENDIAN
+
+#        define htole16(x) (x)
+#        define htole32(x) (x)
+#        define htole64(x) (x)
+
+#        define htobe16(x) ENDIAN_SWAP16(x)
+#        define htobe32(x) ENDIAN_SWAP32(x)
+#        define htobe64(x) ENDIAN_SWAP64(x)
+
+#    else
+
+#        error byte order not supported
+
+#    endif
+
+#    define be16toh(x) ENDIAN_BE16(x)
+#    define be32toh(x) ENDIAN_BE32(x)
+#    define be64toh(x) ENDIAN_BE64(x)
+#    define le16toh(x) ENDIAN_LE16(x)
+#    define le32toh(x) ENDIAN_LE32(x)
+#    define le64toh(x) ENDIAN_LE64(x)
+
+#else
+
+#    error platform not supported
+
+#endif
+
+#endif

--- a/src/query.c
+++ b/src/query.c
@@ -442,7 +442,7 @@ static const CaptureList *capture_list_pool_get(const CaptureListPool *self, uin
 }
 
 static CaptureList *capture_list_pool_get_mut(CaptureListPool *self, uint16_t id) {
-  assert(id < self->list.size);
+  ts_assert(id < self->list.size);
   return &self->list.contents[id];
 }
 
@@ -1695,7 +1695,7 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
       unsigned first_child_step_index = parent_step_index + 1;
       uint32_t j, child_exists;
       array_search_sorted_by(&self->step_offsets, .step_index, first_child_step_index, &j, &child_exists);
-      assert(child_exists);
+      ts_assert(child_exists);
       *error_offset = self->step_offsets.contents[j].byte_offset;
       all_patterns_are_valid = false;
       break;
@@ -1754,7 +1754,7 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
     // If this pattern cannot match, store the pattern index so that it can be
     // returned to the caller.
     if (analysis.finished_parent_symbols.size == 0) {
-      assert(analysis.final_step_indices.size > 0);
+      ts_assert(analysis.final_step_indices.size > 0);
       uint16_t impossible_step_index = *array_back(&analysis.final_step_indices);
       uint32_t j, impossible_exists;
       array_search_sorted_by(&self->step_offsets, .step_index, impossible_step_index, &j, &impossible_exists);
@@ -2932,7 +2932,7 @@ bool ts_query__step_is_fallible(
   const TSQuery *self,
   uint16_t step_index
 ) {
-  assert((uint32_t)step_index + 1 < self->steps.size);
+  ts_assert((uint32_t)step_index + 1 < self->steps.size);
   QueryStep *step = &self->steps.contents[step_index];
   QueryStep *next_step = &self->steps.contents[step_index + 1];
   return (
@@ -4064,7 +4064,7 @@ bool ts_query_cursor_next_capture(
     uint32_t first_unfinished_pattern_index;
     uint32_t first_unfinished_state_index;
     bool first_unfinished_state_is_definite = false;
-    ts_query_cursor__first_in_progress_capture(
+    bool found_unfinished_state = ts_query_cursor__first_in_progress_capture(
       self,
       &first_unfinished_state_index,
       &first_unfinished_capture_byte,
@@ -4154,7 +4154,7 @@ bool ts_query_cursor_next_capture(
       return true;
     }
 
-    if (capture_list_pool_is_empty(&self->capture_list_pool)) {
+    if (capture_list_pool_is_empty(&self->capture_list_pool) && found_unfinished_state) {
       LOG(
         "  abandon state. index:%u, pattern:%u, offset:%u.\n",
         first_unfinished_state_index,

--- a/src/stack.c
+++ b/src/stack.c
@@ -82,9 +82,9 @@ typedef StackAction (*StackCallback)(void *, const StackIterator *);
 static void stack_node_retain(StackNode *self) {
   if (!self)
     return;
-  assert(self->ref_count > 0);
+  ts_assert(self->ref_count > 0);
   self->ref_count++;
-  assert(self->ref_count != 0);
+  ts_assert(self->ref_count != 0);
 }
 
 static void stack_node_release(
@@ -93,7 +93,7 @@ static void stack_node_release(
   SubtreePool *subtree_pool
 ) {
 recur:
-  assert(self->ref_count != 0);
+  ts_assert(self->ref_count != 0);
   self->ref_count--;
   if (self->ref_count > 0) return;
 
@@ -567,7 +567,7 @@ SubtreeArray ts_stack_pop_error(Stack *self, StackVersion version) {
       bool found_error = false;
       StackSliceArray pop = stack__iter(self, version, pop_error_callback, &found_error, 1);
       if (pop.size > 0) {
-        assert(pop.size == 1);
+        ts_assert(pop.size == 1);
         ts_stack_renumber_version(self, pop.contents[0].version, version);
         return pop.contents[0].subtrees;
       }
@@ -663,8 +663,8 @@ void ts_stack_remove_version(Stack *self, StackVersion version) {
 
 void ts_stack_renumber_version(Stack *self, StackVersion v1, StackVersion v2) {
   if (v1 == v2) return;
-  assert(v2 < v1);
-  assert((uint32_t)v1 < self->heads.size);
+  ts_assert(v2 < v1);
+  ts_assert((uint32_t)v1 < self->heads.size);
   StackHead *source_head = &self->heads.contents[v1];
   StackHead *target_head = &self->heads.contents[v2];
   if (target_head->summary && !source_head->summary) {
@@ -683,7 +683,7 @@ void ts_stack_swap_versions(Stack *self, StackVersion v1, StackVersion v2) {
 }
 
 StackVersion ts_stack_copy_version(Stack *self, StackVersion version) {
-  assert(version < self->heads.size);
+  ts_assert(version < self->heads.size);
   array_push(&self->heads, self->heads.contents[version]);
   StackHead *head = array_back(&self->heads);
   stack_node_retain(head->node);
@@ -743,7 +743,7 @@ bool ts_stack_is_paused(const Stack *self, StackVersion version) {
 
 Subtree ts_stack_resume(Stack *self, StackVersion version) {
   StackHead *head = array_get(&self->heads, version);
-  assert(head->status == StackStatusPaused);
+  ts_assert(head->status == StackStatusPaused);
   Subtree result = head->lookahead_when_paused;
   head->status = StackStatusActive;
   head->lookahead_when_paused = NULL_SUBTREE;

--- a/src/stack.h
+++ b/src/stack.h
@@ -7,7 +7,6 @@ extern "C" {
 
 #include "./array.h"
 #include "./subtree.h"
-#include "./error_costs.h"
 #include <stdio.h>
 
 typedef struct Stack Stack;
@@ -29,23 +28,23 @@ typedef struct {
 typedef Array(StackSummaryEntry) StackSummary;
 
 // Create a stack.
-Stack *ts_stack_new(SubtreePool *);
+Stack *ts_stack_new(SubtreePool *subtree_pool);
 
 // Release the memory reserved for a given stack.
-void ts_stack_delete(Stack *);
+void ts_stack_delete(Stack *self);
 
 // Get the stack's current number of versions.
-uint32_t ts_stack_version_count(const Stack *);
+uint32_t ts_stack_version_count(const Stack *self);
 
 // Get the state at the top of the given version of the stack. If the stack is
 // empty, this returns the initial state, 0.
-TSStateId ts_stack_state(const Stack *, StackVersion);
+TSStateId ts_stack_state(const Stack *self, StackVersion version);
 
 // Get the last external token associated with a given version of the stack.
-Subtree ts_stack_last_external_token(const Stack *, StackVersion);
+Subtree ts_stack_last_external_token(const Stack *self, StackVersion version);
 
 // Set the last external token associated with a given version of the stack.
-void ts_stack_set_last_external_token(Stack *, StackVersion, Subtree );
+void ts_stack_set_last_external_token(Stack *self, StackVersion version, Subtree token);
 
 // Get the position of the given version of the stack within the document.
 Length ts_stack_position(const Stack *, StackVersion);
@@ -55,76 +54,74 @@ Length ts_stack_position(const Stack *, StackVersion);
 // This transfers ownership of the tree to the Stack. Callers that
 // need to retain ownership of the tree for their own purposes should
 // first retain the tree.
-void ts_stack_push(Stack *, StackVersion, Subtree , bool, TSStateId);
+void ts_stack_push(Stack *self, StackVersion version, Subtree subtree, bool pending, TSStateId state);
 
 // Pop the given number of entries from the given version of the stack. This
 // operation can increase the number of stack versions by revealing multiple
 // versions which had previously been merged. It returns an array that
 // specifies the index of each revealed version and the trees that were
 // removed from that version.
-StackSliceArray ts_stack_pop_count(Stack *, StackVersion, uint32_t count);
+StackSliceArray ts_stack_pop_count(Stack *self, StackVersion version, uint32_t count);
 
 // Remove an error at the top of the given version of the stack.
-SubtreeArray ts_stack_pop_error(Stack *, StackVersion);
+SubtreeArray ts_stack_pop_error(Stack *self, StackVersion version);
 
 // Remove any pending trees from the top of the given version of the stack.
-StackSliceArray ts_stack_pop_pending(Stack *, StackVersion);
+StackSliceArray ts_stack_pop_pending(Stack *self, StackVersion version);
 
-// Remove any all trees from the given version of the stack.
-StackSliceArray ts_stack_pop_all(Stack *, StackVersion);
+// Remove all trees from the given version of the stack.
+StackSliceArray ts_stack_pop_all(Stack *self, StackVersion version);
 
 // Get the maximum number of tree nodes reachable from this version of the stack
 // since the last error was detected.
-unsigned ts_stack_node_count_since_error(const Stack *, StackVersion);
+unsigned ts_stack_node_count_since_error(const Stack *self, StackVersion version);
 
-int ts_stack_dynamic_precedence(Stack *, StackVersion);
+int ts_stack_dynamic_precedence(Stack *self, StackVersion version);
 
-bool ts_stack_has_advanced_since_error(const Stack *, StackVersion);
+bool ts_stack_has_advanced_since_error(const Stack *self, StackVersion version);
 
 // Compute a summary of all the parse states near the top of the given
 // version of the stack and store the summary for later retrieval.
-void ts_stack_record_summary(Stack *, StackVersion, unsigned max_depth);
+void ts_stack_record_summary(Stack *self, StackVersion version, unsigned max_depth);
 
 // Retrieve a summary of all the parse states near the top of the
 // given version of the stack.
-StackSummary *ts_stack_get_summary(Stack *, StackVersion);
+StackSummary *ts_stack_get_summary(Stack *self, StackVersion version);
 
 // Get the total cost of all errors on the given version of the stack.
-unsigned ts_stack_error_cost(const Stack *, StackVersion version);
+unsigned ts_stack_error_cost(const Stack *self, StackVersion version);
 
 // Merge the given two stack versions if possible, returning true
 // if they were successfully merged and false otherwise.
-bool ts_stack_merge(Stack *, StackVersion, StackVersion);
+bool ts_stack_merge(Stack *self, StackVersion version1, StackVersion version2);
 
 // Determine whether the given two stack versions can be merged.
-bool ts_stack_can_merge(Stack *, StackVersion, StackVersion);
+bool ts_stack_can_merge(Stack *self, StackVersion version1, StackVersion version2);
 
-Subtree ts_stack_resume(Stack *, StackVersion);
+Subtree ts_stack_resume(Stack *self, StackVersion version);
 
-void ts_stack_pause(Stack *, StackVersion, Subtree);
+void ts_stack_pause(Stack *self, StackVersion version, Subtree lookahead);
 
-void ts_stack_halt(Stack *, StackVersion);
+void ts_stack_halt(Stack *self, StackVersion version);
 
-bool ts_stack_is_active(const Stack *, StackVersion);
+bool ts_stack_is_active(const Stack *self, StackVersion version);
 
-bool ts_stack_is_paused(const Stack *, StackVersion);
+bool ts_stack_is_paused(const Stack *self, StackVersion version);
 
-bool ts_stack_is_halted(const Stack *, StackVersion);
+bool ts_stack_is_halted(const Stack *self, StackVersion version);
 
-void ts_stack_renumber_version(Stack *, StackVersion, StackVersion);
+void ts_stack_renumber_version(Stack *self, StackVersion v1, StackVersion v2);
 
-void ts_stack_swap_versions(Stack *, StackVersion, StackVersion);
+void ts_stack_swap_versions(Stack *, StackVersion v1, StackVersion v2);
 
-StackVersion ts_stack_copy_version(Stack *, StackVersion);
+StackVersion ts_stack_copy_version(Stack *self, StackVersion version);
 
 // Remove the given version from the stack.
-void ts_stack_remove_version(Stack *, StackVersion);
+void ts_stack_remove_version(Stack *self, StackVersion version);
 
-void ts_stack_clear(Stack *);
+void ts_stack_clear(Stack *self);
 
-bool ts_stack_print_dot_graph(Stack *, const TSLanguage *, FILE *);
-
-typedef void (*StackIterateCallback)(void *, TSStateId, uint32_t);
+bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f);
 
 #ifdef __cplusplus
 }

--- a/src/subtree.c
+++ b/src/subtree.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <ctype.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -11,6 +10,7 @@
 #include "./length.h"
 #include "./language.h"
 #include "./error_costs.h"
+#include "./ts_assert.h"
 #include <stddef.h>
 
 typedef struct {
@@ -229,7 +229,7 @@ void ts_subtree_set_symbol(
 ) {
   TSSymbolMetadata metadata = ts_language_symbol_metadata(language, symbol);
   if (self->data.is_inline) {
-    assert(symbol < UINT8_MAX);
+    ts_assert(symbol < UINT8_MAX);
     self->data.symbol = symbol;
     self->data.named = metadata.named;
     self->data.visible = metadata.visible;
@@ -371,7 +371,7 @@ void ts_subtree_summarize_children(
   MutableSubtree self,
   const TSLanguage *language
 ) {
-  assert(!self.data.is_inline);
+  ts_assert(!self.data.is_inline);
 
   self.ptr->named_child_count = 0;
   self.ptr->visible_child_count = 0;
@@ -583,16 +583,16 @@ Subtree ts_subtree_new_missing_leaf(
 
 void ts_subtree_retain(Subtree self) {
   if (self.data.is_inline) return;
-  assert(self.ptr->ref_count > 0);
+  ts_assert(self.ptr->ref_count > 0);
   atomic_inc((volatile uint32_t *)&self.ptr->ref_count);
-  assert(self.ptr->ref_count != 0);
+  ts_assert(self.ptr->ref_count != 0);
 }
 
 void ts_subtree_release(SubtreePool *pool, Subtree self) {
   if (self.data.is_inline) return;
   array_clear(&pool->tree_stack);
 
-  assert(self.ptr->ref_count > 0);
+  ts_assert(self.ptr->ref_count > 0);
   if (atomic_dec((volatile uint32_t *)&self.ptr->ref_count) == 0) {
     array_push(&pool->tree_stack, ts_subtree_to_mut_unsafe(self));
   }
@@ -604,7 +604,7 @@ void ts_subtree_release(SubtreePool *pool, Subtree self) {
       for (uint32_t i = 0; i < tree.ptr->child_count; i++) {
         Subtree child = children[i];
         if (child.data.is_inline) continue;
-        assert(child.ptr->ref_count > 0);
+        ts_assert(child.ptr->ref_count > 0);
         if (atomic_dec((volatile uint32_t *)&child.ptr->ref_count) == 0) {
           array_push(&pool->tree_stack, ts_subtree_to_mut_unsafe(child));
         }
@@ -677,7 +677,8 @@ Subtree ts_subtree_edit(Subtree self, const TSInputEdit *input_edit, SubtreePool
     Edit edit = entry.edit;
     bool is_noop = edit.old_end.bytes == edit.start.bytes && edit.new_end.bytes == edit.start.bytes;
     bool is_pure_insertion = edit.old_end.bytes == edit.start.bytes;
-    bool invalidate_first_row = ts_subtree_depends_on_column(*entry.tree);
+    bool parent_depends_on_column = ts_subtree_depends_on_column(*entry.tree);
+    bool column_shifted = edit.new_end.extent.column != edit.old_end.extent.column;
 
     Length size = ts_subtree_size(*entry.tree);
     Length padding = ts_subtree_padding(*entry.tree);
@@ -771,8 +772,12 @@ Subtree ts_subtree_edit(Subtree self, const TSInputEdit *input_edit, SubtreePool
         (child_left.bytes > edit.old_end.bytes) ||
         (child_left.bytes == edit.old_end.bytes && child_size.bytes > 0 && i > 0)
       ) && (
-        !invalidate_first_row ||
-        child_left.extent.row > entry.tree->ptr->padding.extent.row
+        !parent_depends_on_column ||
+        child_left.extent.row > padding.extent.row
+      ) && (
+        !ts_subtree_depends_on_column(*child) ||
+        !column_shifted ||
+        child_left.extent.row > edit.old_end.extent.row
       )) {
         break;
       }
@@ -985,6 +990,7 @@ void ts_subtree__print_dot_graph(const Subtree *self, uint32_t start_offset,
 
   if (ts_subtree_child_count(*self) == 0) fprintf(f, ", shape=plaintext");
   if (ts_subtree_extra(*self)) fprintf(f, ", fontcolor=gray");
+  if (ts_subtree_has_changes(*self)) fprintf(f, ", color=green, penwidth=2");
 
   fprintf(f, ", tooltip=\""
     "range: %u - %u\n"

--- a/src/tree.c
+++ b/src/tree.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200112L
-
 #include "tree_sitter/api.h"
 #include "./array.h"
 #include "./get_changed_ranges.h"
@@ -148,7 +146,7 @@ void ts_tree_print_dot_graph(const TSTree *self, int fd) {
   fclose(file);
 }
 
-#else
+#elif !defined(__wasi__) // WASI doesn't support dup
 
 #include <unistd.h>
 
@@ -160,6 +158,13 @@ void ts_tree_print_dot_graph(const TSTree *self, int file_descriptor) {
   FILE *file = fdopen(_ts_dup(file_descriptor), "a");
   ts_subtree_print_dot_graph(self->root, self->language, file);
   fclose(file);
+}
+
+#else
+
+void ts_tree_print_dot_graph(const TSTree *self, int file_descriptor) {
+  (void)self;
+  (void)file_descriptor;
 }
 
 #endif

--- a/src/tree.h
+++ b/src/tree.h
@@ -21,8 +21,8 @@ struct TSTree {
   unsigned included_range_count;
 };
 
-TSTree *ts_tree_new(Subtree root, const TSLanguage *language, const TSRange *, unsigned);
-TSNode ts_node_new(const TSTree *, const Subtree *, Length, TSSymbol);
+TSTree *ts_tree_new(Subtree root, const TSLanguage *language, const TSRange *included_ranges, unsigned included_range_count);
+TSNode ts_node_new(const TSTree *tree, const Subtree *subtree, Length position, TSSymbol alias);
 
 #ifdef __cplusplus
 }

--- a/src/tree_cursor.c
+++ b/src/tree_cursor.c
@@ -274,7 +274,7 @@ static inline int64_t ts_tree_cursor_goto_first_child_for_byte_and_point(
     CursorChildIterator iterator = ts_tree_cursor_iterate_children(self);
     while (ts_tree_cursor_child_iterator_next(&iterator, &entry, &visible)) {
       Length entry_end = length_add(entry.position, ts_subtree_size(*entry.subtree));
-      bool at_goal = entry_end.bytes >= goal_byte && point_gte(entry_end.extent, goal_point);
+      bool at_goal = entry_end.bytes > goal_byte && point_gt(entry_end.extent, goal_point);
       uint32_t visible_child_count = ts_subtree_visible_child_count(*entry.subtree);
       if (at_goal) {
         if (visible) {

--- a/src/tree_cursor.h
+++ b/src/tree_cursor.h
@@ -23,19 +23,19 @@ typedef enum {
   TreeCursorStepVisible,
 } TreeCursorStep;
 
-void ts_tree_cursor_init(TreeCursor *, TSNode);
+void ts_tree_cursor_init(TreeCursor *self, TSNode node);
 void ts_tree_cursor_current_status(
-  const TSTreeCursor *,
-  TSFieldId *,
-  bool *,
-  bool *,
-  bool *,
-  TSSymbol *,
-  unsigned *
+  const TSTreeCursor *_self,
+  TSFieldId *field_id,
+  bool *has_later_siblings,
+  bool *has_later_named_siblings,
+  bool *can_have_later_siblings_with_this_field,
+  TSSymbol *supertypes,
+  unsigned *supertype_count
 );
 
-TreeCursorStep ts_tree_cursor_goto_first_child_internal(TSTreeCursor *);
-TreeCursorStep ts_tree_cursor_goto_next_sibling_internal(TSTreeCursor *);
+TreeCursorStep ts_tree_cursor_goto_first_child_internal(TSTreeCursor *_self);
+TreeCursorStep ts_tree_cursor_goto_next_sibling_internal(TSTreeCursor *_self);
 
 static inline Subtree ts_tree_cursor_current_subtree(const TSTreeCursor *_self) {
   const TreeCursor *self = (const TreeCursor *)_self;
@@ -43,6 +43,6 @@ static inline Subtree ts_tree_cursor_current_subtree(const TSTreeCursor *_self) 
   return *last_entry->subtree;
 }
 
-TSNode ts_tree_cursor_parent_node(const TSTreeCursor *);
+TSNode ts_tree_cursor_parent_node(const TSTreeCursor *_self);
 
 #endif  // TREE_SITTER_TREE_CURSOR_H_

--- a/src/ts_assert.h
+++ b/src/ts_assert.h
@@ -1,0 +1,11 @@
+#ifndef TREE_SITTER_ASSERT_H_
+#define TREE_SITTER_ASSERT_H_
+
+#ifdef NDEBUG
+#define ts_assert(e) ((void)(e))
+#else
+#include <assert.h>
+#define ts_assert(e) assert(e)
+#endif
+
+#endif // TREE_SITTER_ASSERT_H_

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -12,6 +12,29 @@ extern "C" {
 #define U_EXPORT2
 #include "unicode/utf8.h"
 #include "unicode/utf16.h"
+#include "portable/endian.h"
+
+#define U16_NEXT_LE(s, i, length, c) UPRV_BLOCK_MACRO_BEGIN { \
+    (c)=le16toh((s)[(i)++]); \
+    if(U16_IS_LEAD(c)) { \
+        uint16_t __c2; \
+        if((i)!=(length) && U16_IS_TRAIL(__c2=(s)[(i)])) { \
+            ++(i); \
+            (c)=U16_GET_SUPPLEMENTARY((c), __c2); \
+        } \
+    } \
+} UPRV_BLOCK_MACRO_END
+
+#define U16_NEXT_BE(s, i, length, c) UPRV_BLOCK_MACRO_BEGIN { \
+    (c)=be16toh((s)[(i)++]); \
+    if(U16_IS_LEAD(c)) { \
+        uint16_t __c2; \
+        if((i)!=(length) && U16_IS_TRAIL(__c2=(s)[(i)])) { \
+            ++(i); \
+            (c)=U16_GET_SUPPLEMENTARY((c), __c2); \
+        } \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 static const int32_t TS_DECODE_ERROR = U_SENTINEL;
 
@@ -33,13 +56,23 @@ static inline uint32_t ts_decode_utf8(
   return i;
 }
 
-static inline uint32_t ts_decode_utf16(
+static inline uint32_t ts_decode_utf16_le(
   const uint8_t *string,
   uint32_t length,
   int32_t *code_point
 ) {
   uint32_t i = 0;
-  U16_NEXT(((uint16_t *)string), i, length, *code_point);
+  U16_NEXT_LE(((uint16_t *)string), i, length, *code_point);
+  return i * 2;
+}
+
+static inline uint32_t ts_decode_utf16_be(
+  const uint8_t *string,
+  uint32_t length,
+  int32_t *code_point
+) {
+  uint32_t i = 0;
+  U16_NEXT_BE(((uint16_t *)string), i, length, *code_point);
   return i * 2;
 }
 

--- a/src/wasm_store.h
+++ b/src/wasm_store.h
@@ -8,21 +8,21 @@ extern "C" {
 #include "tree_sitter/api.h"
 #include "./parser.h"
 
-bool ts_wasm_store_start(TSWasmStore *, TSLexer *, const TSLanguage *);
-void ts_wasm_store_reset(TSWasmStore *);
-bool ts_wasm_store_has_error(const TSWasmStore *);
+bool ts_wasm_store_start(TSWasmStore *self, TSLexer *lexer, const TSLanguage *language);
+void ts_wasm_store_reset(TSWasmStore *self);
+bool ts_wasm_store_has_error(const TSWasmStore *self);
 
-bool ts_wasm_store_call_lex_main(TSWasmStore *, TSStateId);
-bool ts_wasm_store_call_lex_keyword(TSWasmStore *, TSStateId);
+bool ts_wasm_store_call_lex_main(TSWasmStore *self, TSStateId state);
+bool ts_wasm_store_call_lex_keyword(TSWasmStore *self, TSStateId state);
 
-uint32_t ts_wasm_store_call_scanner_create(TSWasmStore *);
-void ts_wasm_store_call_scanner_destroy(TSWasmStore *, uint32_t);
-bool ts_wasm_store_call_scanner_scan(TSWasmStore *, uint32_t, uint32_t);
-uint32_t ts_wasm_store_call_scanner_serialize(TSWasmStore *, uint32_t, char *);
-void ts_wasm_store_call_scanner_deserialize(TSWasmStore *, uint32_t, const char *, unsigned);
+uint32_t ts_wasm_store_call_scanner_create(TSWasmStore *self);
+void ts_wasm_store_call_scanner_destroy(TSWasmStore *self, uint32_t scanner_address);
+bool ts_wasm_store_call_scanner_scan(TSWasmStore *self, uint32_t scanner_address, uint32_t valid_tokens_ix);
+uint32_t ts_wasm_store_call_scanner_serialize(TSWasmStore *self, uint32_t scanner_address, char *buffer);
+void ts_wasm_store_call_scanner_deserialize(TSWasmStore *self, uint32_t scanner, const char *buffer, unsigned length);
 
-void ts_wasm_language_retain(const TSLanguage *);
-void ts_wasm_language_release(const TSLanguage *);
+void ts_wasm_language_retain(const TSLanguage *self);
+void ts_wasm_language_release(const TSLanguage *self);
 
 #ifdef __cplusplus
 }

--- a/tree.go
+++ b/tree.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/tree_cursor.go
+++ b/tree_cursor.go
@@ -1,7 +1,7 @@
 package tree_sitter
 
 /*
-#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L
+#cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 */
 import "C"

--- a/tree_test.go
+++ b/tree_test.go
@@ -528,12 +528,13 @@ func TestTreeCursorChildForPoint(t *testing.T) {
 	assert.Equal(t, c.Node().Kind(), "program")
 
 	// descend to expression statement
-	assert.EqualValues(t, *c.GotoFirstChildForPoint(Point{Row: 6, Column: 6}), 0)
+	assert.EqualValues(t, *c.GotoFirstChildForPoint(Point{Row: 6, Column: 5}), 0)
 	assert.Equal(t, c.Node().Kind(), "expression_statement")
 
 	// step into ';' and back up
 	assert.Nil(t, c.GotoFirstChildForPoint(Point{Row: 7, Column: 0}))
-	assert.EqualValues(t, *c.GotoFirstChildForPoint(Point{Row: 6, Column: 6}), 1)
+	assert.Nil(t, c.GotoFirstChildForPoint(Point{Row: 6, Column: 6}))
+	assert.EqualValues(t, *c.GotoFirstChildForPoint(Point{Row: 6, Column: 5}), 1)
 	assert.Equal(t, c.Node().Kind(), ";")
 	assert.Equal(t, c.Node().StartPosition(), Point{Row: 6, Column: 5})
 	assert.True(t, c.GotoParent())
@@ -560,7 +561,7 @@ func TestTreeCursorChildForPoint(t *testing.T) {
 	assert.True(t, c.GotoParent())
 
 	// step into first ',' and back up
-	assert.EqualValues(t, *c.GotoFirstChildForPoint(Point{Row: 1, Column: 12}), 2)
+	assert.EqualValues(t, *c.GotoFirstChildForPoint(Point{Row: 1, Column: 11}), 2)
 	assert.Equal(t, c.Node().Kind(), ",")
 	assert.Equal(t, c.Node().StartPosition(), Point{Row: 1, Column: 11})
 	assert.True(t, c.GotoParent())


### PR DESCRIPTION
Features:
 - utf16 little and big endian distinction for parsing (just "utf16" is deprecated)
 - Supertype symbol detection
 - Node.FieldNameForNamedChild
 - Node.ChildWithDescendant to replace Node.ChildContainingDescendant