### PR TITLE
feat: add Node.Equals

### DIFF
--- a/node.go
+++ b/node.go
@@ -391,3 +391,8 @@ func (n *Node) Walk() *TreeCursor {
 func (n *Node) Edit(edit *InputEdit) {
 	C.ts_node_edit(&n._inner, edit.toTSInputEdit())
 }
+
+// Check if two nodes are identical.
+func (n *Node) Equals(other Node) bool {
+	return bool(C.ts_node_eq(n._inner, other._inner))
+}


### PR DESCRIPTION
Adds the missing `ts_node_eq`:
https://github.com/tree-sitter/go-tree-sitter/blob/5432ade78ad6bde797bcdaa272a5953eaba83971/include/tree_sitter/api.h#L684