### PR TITLE
refactor: captures unsafe casting from TSQueryMatch

### DIFF
--- a/query.go
+++ b/query.go
@@ -792,7 +792,8 @@ func (qm *QueryMatch) Id() uint {
 func newQueryMatch(m *C.TSQueryMatch, cursor *C.TSQueryCursor) QueryMatch {
 	var captures []QueryCapture
 	if m.capture_count > 0 {
-		captures = (*[1 << 16]QueryCapture)(unsafe.Pointer(m.captures))[:m.capture_count:m.capture_count]
+		cc := unsafe.Slice(m.captures, m.capture_count)
+		captures = *(*[]QueryCapture)(unsafe.Pointer(&cc))
 	}
 	return QueryMatch{
 		cursor:       cursor,
@@ -917,6 +918,9 @@ func NewQueryProperty(key string, value *string, captureId *uint) QueryProperty 
 
 // Next will return the next match in the sequence of matches.
 //
+// Subsequent calls to [QueryMatches.Next] will reuse the same memory,
+// this means that you need to copy/take out what you need from the [QueryMatch] before calling [QueryMatches.Next] again.
+//
 // If there are no more matches, it will return nil.
 func (qm *QueryMatches) Next() *QueryMatch {
 	for {
@@ -939,6 +943,9 @@ func (qm *QueryMatches) Next() *QueryMatch {
 }
 
 // Next will return the next match in the sequence of matches, as well as the index of the capture.
+//
+// Subsequent calls to [QueryCaptures.Next] will reuse the same memory,
+// this means that you need to copy/take out what you need from the [QueryMatch] before calling [QueryCaptures.Next] again.
 //
 // If there are no more matches, it will return nil.
 func (qc *QueryCaptures) Next() (*QueryMatch, uint) {

--- a/query.go
+++ b/query.go
@@ -918,8 +918,8 @@ func NewQueryProperty(key string, value *string, captureId *uint) QueryProperty 
 
 // Next will return the next match in the sequence of matches.
 //
-// Subsequent calls to [QueryMatches.Next] will reuse the same memory,
-// this means that you need to copy/take out what you need from the [QueryMatch] before calling [QueryMatches.Next] again.
+// Subsequent calls to [QueryMatches.Next] will overwrite the memory at the same location as prior matches, since the memory is reused. You can think of this as a stateful iterator.
+// If you need to keep the data of a prior match without it being overwritten, you should copy what you need before calling [QueryMatches.Next] again.
 //
 // If there are no more matches, it will return nil.
 func (qm *QueryMatches) Next() *QueryMatch {
@@ -944,8 +944,8 @@ func (qm *QueryMatches) Next() *QueryMatch {
 
 // Next will return the next match in the sequence of matches, as well as the index of the capture.
 //
-// Subsequent calls to [QueryCaptures.Next] will reuse the same memory,
-// this means that you need to copy/take out what you need from the [QueryMatch] before calling [QueryCaptures.Next] again.
+// Subsequent calls to [QueryCaptures.Next] will overwrite the memory at the same location as prior matches, since the memory is reused. You can think of this as a stateful iterator.
+// If you need to keep the data of a prior match without it being overwritten, you should copy what you need before calling [QueryCaptures.Next] again.
 //
 // If there are no more matches, it will return nil.
 func (qc *QueryCaptures) Next() (*QueryMatch, uint) {

--- a/query.go
+++ b/query.go
@@ -792,8 +792,8 @@ func (qm *QueryMatch) Id() uint {
 func newQueryMatch(m *C.TSQueryMatch, cursor *C.TSQueryCursor) QueryMatch {
 	var captures []QueryCapture
 	if m.capture_count > 0 {
-		cc := unsafe.Slice(m.captures, m.capture_count)
-		captures = *(*[]QueryCapture)(unsafe.Pointer(&cc))
+		cCaptures := unsafe.Slice(m.captures, m.capture_count)
+		captures = *(*[]QueryCapture)(unsafe.Pointer(&cCaptures))
 	}
 	return QueryMatch{
 		cursor:       cursor,


### PR DESCRIPTION
I ran into the issue that captures didn't work correctly and apparently this code was breaking unsafe rules. I fixed it with some help of a friend.

I also changed QueryCapture.Index to `uint` which does not make the struct C-compatible anymore but nicer to use since you don't need to do that manually anymore