### PR TITLE
Remove unnecessary allocator trampoline

### DIFF
--- a/allocator.go
+++ b/allocator.go
@@ -4,6 +4,10 @@ package tree_sitter
 #cgo CFLAGS: -Iinclude -Isrc -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 #include <tree_sitter/api.h>
 #include "allocator.h"
+
+static inline void ts_use_libc_allocator(void) {
+    ts_set_allocator(malloc, calloc, realloc, free);
+}
 */
 import "C"
 
@@ -62,6 +66,11 @@ func SetAllocator(
 	newRealloc func(ptr unsafe.Pointer, size uint) unsafe.Pointer,
 	newFree func(ptr unsafe.Pointer),
 ) {
+	if newMalloc == nil && newCalloc == nil && newRealloc == nil && newFree == nil {
+		C.ts_use_libc_allocator()
+		return
+	}
+
 	if newMalloc != nil {
 		malloc_fn.Store(func(size C.size_t) unsafe.Pointer {
 			return newMalloc(uint(size))


### PR DESCRIPTION
Currently, every allocation from tree-sitter calls back to a Go shim for alloc/calloc/realloc/free operations. If `SetAllocator` is called with all nil values (the default), this has the effect of calling `C.{alloc,calloc,realloc,free}` and keeps all memory operations on the C side. However, this also incurs a C -> Go -> C boundary crossing for every allocation and free, which can be massively expensive when parsing at scale.

This PR changes the behavior of `SetAllocator` to remove the C -> Go -> C trampoline when there are no Go-side shims to execute. If any of the allocation parameters are non-nil, we'll fall back to the current behavior of installing shims for all four methods. I'm assuming common use of this is to replace _all_ of these methods uniformly.

On a representative parse over 30,940 files, I see a decrease from 22,615ms to 5,517ms with this simple change. And see the following disappear completely from the CPU profile:

```
     0.03s 0.028% 98.25%     15.77s 14.85%  _cgoexp_7843849ca2c7_go_free
     0.03s 0.028% 98.28%     20.09s 18.91%  _cgoexp_7843849ca2c7_go_malloc
```