### PR TITLE
fix: Update build constraints to include FreeBSD

### DIFF
--- a/dup_unix.go
+++ b/dup_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || freebsd
 
 package tree_sitter
 


### PR DESCRIPTION
While compiling [ore](https://github.com/contriboss/ore-light)  in freebsd, i noticed tag is missing.