### PR TITLE
feat: replace node pointer in place for much cheaper AST traversal

### DIFF
--- a/tree_cursor.go
+++ b/tree_cursor.go
@@ -28,6 +28,18 @@ func (tc *TreeCursor) Node() *Node {
 	return newNode(C.ts_tree_cursor_current_node(&tc._inner))
 }
 
+// UpdateNode updates an existing Node's internal state to the cursor's current position.
+// This avoids allocation by reusing the provided Node, enabling zero-allocation AST traversal.
+// Returns true if the node was updated successfully, false if cursor is at an invalid position.
+func (tc *TreeCursor) UpdateNode(n *Node) bool {
+	inner := C.ts_tree_cursor_current_node(&tc._inner)
+	if inner.id == nil {
+		return false
+	}
+	n._inner = inner
+	return true
+}
+
 // Get the numerical field id of this tree cursor's current node.
 //
 // See also [TreeCursor.FieldName].


### PR DESCRIPTION
This is a small addition that can make a significant dent in Go GC pressure under certain conditions. In something I'm building I was able to reduce my `*Node` allocations by 96%. 

The standard pattern of calling cursor.Node() at each position allocates a new `*Node` wrapper. On certain batch jobs on very large codebases this can accumulate a lot of allocations. 

It's additive so no compatibility issues with pre-existing implementations. 

```go
// Basic DFS traversal with node reuse
node := rootNode 
cursor := node.Walk()
defer cursor.Close()
current := cursor.Node() // allocate once
for {
    // Process current node
    doSomething(current)
    
    if cursor.GotoFirstChild() {
        cursor.UpdateNode(current) // update in place, no allocation
        continue
    }
    for !cursor.GotoNextSibling() {
        if !cursor.GotoParent() {
            return
        }
    }
    cursor.UpdateNode(current)
}```